### PR TITLE
PP-87: Fix tests

### DIFF
--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -174,7 +174,8 @@ describe('SDK not deployed tests', () => {
         const options: RelayingTransactionOptions = {
             smartWallet,
             unsignedTx,
-            tokenAmount: 0
+            tokenAmount: 0,
+            tokenAddress: MOCK_TOKEN_ADDRESS
         };
 
         try {


### PR DESCRIPTION
## What

- Add the missing parameter `tokenAddress` in  the tests

## Why

- The tests are failing
